### PR TITLE
Added ability to scale vector output and ability to use luma as area instead of radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ To install
   - **`-f <filename>`** : the input filename.  Accepts JPEG, PNG and GIF as input.
   - **`-o <filename>`** : the output filename. Default is original name with SVG suffix.
   - **`-b <int>`** : the box size in pixels.
+  - **`-s <int>`** : the scale with which svg fill will be scaled compared to original file.
   - **`-t`** : luma threshold (0.0 to 1.0)
   - **`-l`** : use BT.701 luma function instead of BT.601 to give more
     weight to red and blue
   - **`-c`** : use average color for area rather than just black (default true)
+  - **`-a`** : use the luma as the surface area instead of the radius (default false)
 
 Example usages
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var (
 	inputFile     = flag.String("f", "", "input image in either JPEG, PNG or GIF")
 	outputFile    = flag.String("o", "", "Output file")
 	boxSize       = flag.Int("b", 50, "Box size for dots")
-	scale         = flag.Int("s", 1, "Scale with which svg coordinates will be scaled")
+	scale         = flag.Int("s", 1, "Scale with which svg fill will be scaled compared to original file")
 	lumaThreshold = flag.Float64("t", 1.0, "Luma threshold - don't draw dots above this luminescence value.  Value from 0.0 to 1.0")
 	color         = flag.Bool("c", true, "Use average color for area rather than just black")
 	bt701         = flag.Bool("l", false, "Use BT.701 instead of BT.601 for luma calculations")


### PR DESCRIPTION
Scaling: Adding the scaling factor allows for changing the output format compared to the input file format. This also allows for finer differences in point size to be visible. Previously the conversion from float to int resulted in generation of large chunks of points of the same size. With the scaling factor these points should now be able differ from each other.

Area: This tag can be used to use the luma as the area of the points instead of using luma as the radius of the points.